### PR TITLE
Adds support for experimental-cross-module-incremental-build for wmo

### DIFF
--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -466,7 +466,7 @@ private:
             typename std::enable_if<Request::isDependencySource>::type * = nullptr>
   void handleDependencySourceRequest(const Request &r) {
     auto source = r.readDependencySource(recorder);
-    if (!source.isNull() && source.get()->isPrimary()) {
+    if (!source.isNull()) {
       recorder.handleDependencySourceRequest(r, source.get());
     }
   }

--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -198,6 +198,9 @@ public:
   CompileJobAction(Action *Input, file_types::ID OutputType, InputInfo info)
       : IncrementalJobAction(Action::Kind::CompileJob, Input, OutputType,
                              info) {}
+  CompileJobAction(file_types::ID OutputType, InputInfo info)
+      : IncrementalJobAction(Action::Kind::CompileJob, None, OutputType, info) {
+  }
 
   static bool classof(const Action *A) {
     return A->getKind() == Action::Kind::CompileJob;

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -319,7 +319,8 @@ public:
   /// \param TC The ToolChain to build Jobs with.
   /// \param C The Compilation containing the Actions for which Jobs should be
   /// created.
-  void buildJobs(ArrayRef<const Action *> TopLevelActions, const OutputInfo &OI,
+  void buildJobs(ArrayRef<const Action *> TopLevelActions,
+                 InputInfoMap *inputInfoMap, const OutputInfo &OI,
                  const OutputFileMap *OFM, StringRef workingDirectory,
                  const ToolChain &TC, Compilation &C) const;
 
@@ -338,9 +339,9 @@ public:
   ///
   /// \returns a Job for the given Action/ToolChain pair
   Job *buildJobsForAction(Compilation &C, const JobAction *JA,
-                          const OutputFileMap *OFM,
-                          StringRef workingDirectory,
-                          bool AtTopLevel, JobCacheMap &JobCache) const;
+                          InputInfoMap *inputInfoMap, const OutputFileMap *OFM,
+                          StringRef workingDirectory, bool AtTopLevel,
+                          JobCacheMap &JobCache) const;
 
 private:
   void computeMainOutput(Compilation &C, const JobAction *JA,

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -327,6 +327,8 @@ public:
   /// compensates.
   Changes loadFromPath(const driver::Job *, StringRef, DiagnosticEngine &);
 
+  Changes loadFromPathWmo(const driver::Job *, StringRef, DiagnosticEngine &);
+
   Changes loadFromSourceFileDepGraph(const driver::Job *cmd,
                                      const SourceFileDepGraph &,
                                      DiagnosticEngine &);

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -20,6 +20,7 @@
 #include "swift/Driver/Action.h"
 #include "swift/Driver/Util.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -308,6 +309,9 @@ private:
   /// The modification time of the main input file, if any.
   llvm::sys::TimePoint<> InputModTime = llvm::sys::TimePoint<>::max();
 
+  llvm::SmallMapVector<const llvm::opt::Arg *, llvm::sys::TimePoint<>, 16>
+      inputPreviousModTimeMap;
+
 #ifndef NDEBUG
   /// The "wave" of incremental jobs that this \c Job was scheduled into.
   ///
@@ -376,6 +380,11 @@ public:
   llvm::sys::TimePoint<> getInputModTime() const {
     return InputModTime;
   }
+
+  void setModtimeForInput(const llvm::opt::Arg *Input,
+                          llvm::sys::TimePoint<> PreviousModTime);
+
+  llvm::sys::TimePoint<> getModTimeforInput(const llvm::opt::Arg *Input) const;
 
   ArrayRef<std::pair<const char *, const char *>> getExtraEnvironment() const {
     return ExtraEnvironment;

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -450,6 +450,18 @@ StringRef Job::getFirstSwiftPrimaryInput() const {
   return StringRef();
 }
 
+void Job::setModtimeForInput(const llvm::opt::Arg *Input,
+                             llvm::sys::TimePoint<> PreviousModTime) {
+  inputPreviousModTimeMap[Input] = PreviousModTime;
+}
+
+llvm::sys::TimePoint<>
+Job::getModTimeforInput(const llvm::opt::Arg *Input) const {
+  auto it = inputPreviousModTimeMap.find(Input);
+  return it == inputPreviousModTimeMap.end() ? llvm::sys::TimePoint<>::max()
+                                             : it->second;
+}
+
 BatchJob::BatchJob(const JobAction &Source,
                    SmallVectorImpl<const Job *> &&Inputs,
                    std::unique_ptr<CommandOutput> Output,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -542,6 +542,11 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back("-track-system-dependencies");
   }
 
+  if (context.Args.hasArg(
+          options::OPT_enable_experimental_cross_module_incremental_build)) {
+    Arguments.push_back("-enable-experimental-cross-module-incremental-build");
+  }
+
   if (context.Args.hasFlag(options::OPT_static_executable,
                            options::OPT_no_static_executable, false) ||
       context.Args.hasFlag(options::OPT_static_stdlib,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -207,8 +207,7 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
 
   // For the time being, we only need to record dependencies in batch mode
   // and single file builds.
-  Invocation.getLangOptions().RecordRequestReferences
-    = !isWholeModuleCompilation();
+  Invocation.getLangOptions().RecordRequestReferences = true;
 
   Context.reset(ASTContext::get(
       Invocation.getLangOptions(), Invocation.getTypeCheckerOptions(),
@@ -1083,11 +1082,8 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
     opts |= SourceFile::ParsingFlags::SuppressWarnings;
   }
 
-  // Enable interface hash computation for primaries, but not in WMO, as it's
-  // only currently needed for incremental mode.
-  if (forPrimary) {
-    opts |= SourceFile::ParsingFlags::EnableInterfaceHash;
-  }
+  opts |= SourceFile::ParsingFlags::EnableInterfaceHash;
+
   return opts;
 }
 


### PR DESCRIPTION
From our experience, when compiling a large codebase with 200+ modules `wmo` builds are almost always quicker than the traditional `-incremental` or `-batchmode` builds.  So enables the `experimental-cross-module-incremental-build` feature for wmo such that we can prevent unnecessary cascading of builds.

This is still experimental and a work in process and has been only tested with [tapthaker/cross-module-incremental-build-example](https://github.com/tapthaker/cross-module-incremental-build-example)

Before:
```
Using $SWIFT_BINARY as /usr/bin/swiftc
Incremental compilation has been disabled, because it is not compatible with whole module optimization.Adding standard job to task queue: {compile: C.o <= C.swift}
Added to TaskQueue: {compile: C.o <= C.swift}
Job finished: {compile: C.o <= C.swift}
Incremental compilation has been disabled, because it is not compatible with whole module optimization.Adding standard job to task queue: {compile: B.o <= B.swift}
Added to TaskQueue: {compile: B.o <= B.swift}
Job finished: {compile: B.o <= B.swift}
Incremental compilation has been disabled, because it is not compatible with whole module optimization.Adding standard job to task queue: {compile: A.o <= A.swift}
Added to TaskQueue: {compile: A.o <= A.swift}
Job finished: {compile: A.o <= A.swift}

Press any key to continue
Incremental compilation has been disabled, because it is not compatible with whole module optimization.Adding standard job to task queue: {compile: C.o <= C.swift}
Added to TaskQueue: {compile: C.o <= C.swift}
Job finished: {compile: C.o <= C.swift}
Incremental compilation has been disabled, because it is not compatible with whole module optimization.Adding standard job to task queue: {compile: B.o <= B.swift}
Added to TaskQueue: {compile: B.o <= B.swift}
Job finished: {compile: B.o <= B.swift}
Incremental compilation has been disabled, because it is not compatible with whole module optimization.Adding standard job to task queue: {compile: A.o <= A.swift}
Added to TaskQueue: {compile: A.o <= A.swift}
Job finished: {compile: A.o <= A.swift}
```

Now:

```
Using $SWIFT_BINARY as /Users/swift-source/build/Xcode-DebugAssert/swift-macosx-x86_64/Debug/bin/swift-frontend
Incremental compilation could not read build record.
Disabling incremental build: could not read build record
Adding standard job to task queue: {compile: C.o <= C.swift}
Added to TaskQueue: {compile: C.o <= C.swift}
Job finished: {compile: C.o <= C.swift}
Incremental compilation could not read build record.
Disabling incremental build: could not read build record
Adding standard job to task queue: {compile: B.o <= B.swift}
Added to TaskQueue: {compile: B.o <= B.swift}
Job finished: {compile: B.o <= B.swift}
Incremental compilation could not read build record.
Disabling incremental build: could not read build record
Adding standard job to task queue: {compile: A.o <= A.swift}
Added to TaskQueue: {compile: A.o <= A.swift}
Job finished: {compile: A.o <= A.swift}

Press any key to continue
Adding standard job to task queue: {compile: C.o <= C.swift}
Added to TaskQueue: {compile: C.o <= C.swift}
Job finished: {compile: C.o <= C.swift}
Queuing because of incremental external dependencies: {compile: B.o <= B.swift}
        interface of top-level name 'fromC' in /Users/tapanth/Uber/test-skip-transitive-recompilation/C.swiftmodule -> implementation of source file B.swift.swiftdeps
Adding standard job to task queue: {compile: B.o <= B.swift}
Added to TaskQueue: {compile: B.o <= B.swift}
Job finished: {compile: B.o <= B.swift}
Job skipped: {compile: A.o <= A.swift}
```
